### PR TITLE
Modify setup script for OCP

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,4 @@
-metallb_path="/home/lnoy/go/src/github.com/liornoy/metallb"
+metallb_path="/home/lnoy/go/src/github.com/liornoy/net/metallb"
 echo "Starting clean up script"
 docker rm -f ibgp-single-hop ibgp-multi-hop ebgp-single-hop ebgp-multi-hop
 rm -rf ${metallb_path}/e2etest/ibgp-single-hop ${metallb_path}/e2etest/ibgp-multi-hop ${metallb_path}/e2etest/ebgp-single-hop ${metallb_path}/e2etest/ebgp-multi-hop

--- a/qe_ci_test_run.sh
+++ b/qe_ci_test_run.sh
@@ -1,14 +1,19 @@
 # run metallb e2e tests with existing docker containers.
 echo "Starting setup for testing ibgp-single-hop container"
-
+export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
+export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
+export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
 frr_image="frr:v7.5.1"
-metallb_path="/home/lnoy/go/src/github.com/liornoy/metallb"
+metallb_path="/home/lnoy/go/src/github.com/liornoy/net/metallb"
 script_path=${PWD}
 
 cp -r ibgp-single-hop ${metallb_path}/e2etest
 cd ${metallb_path}
-docker run -d --privileged  --name ibgp-single-hop --network kind --rm -v ${PWD}/e2etest/ibgp-single-hop/:/etc/frr frrouting/${frr_image}
-invoke e2etest --external-containers="ibgp-single-hop"
+docker run -d --privileged  --name ibgp-single-hop --network host --rm -v ${PWD}/e2etest/ibgp-single-hop/:/etc/frr frrouting/${frr_image}
+invoke e2etest --kubeconfig="KUBECONFIG_PATH" \
+--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
+--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
+--external-containers="ibgp-single-hop"
 
 echo "Starting setup for testing multi-hop scenrio"
 cd ${script_path}
@@ -17,10 +22,10 @@ cp -r ebgp-multi-hop ${metallb_path}/e2etest
 cp -r ibgp-multi-hop ${metallb_path}/e2etest
 
 cd ${metallb_path}
-# Set up the multi-hop-net. This will differ in the real qe ci.
+
 docker network create multi-hop-net --ipv6 --driver=bridge --subnet=172.30.0.0/16 --subnet=fc00:f853:ccd:e798::/64
 
-docker run -d --privileged  --name ebgp-single-hop --network kind --rm -v ${PWD}/e2etest/ebgp-single-hop/:/etc/frr frrouting/${frr_image}
+docker run -d --privileged  --name ebgp-single-hop --network host --rm -v ${PWD}/e2etest/ebgp-single-hop/:/etc/frr frrouting/${frr_image}
 docker run -d --privileged  --name ebgp-multi-hop --network multi-hop-net --rm -v ${PWD}/e2etest/ebgp-multi-hop/:/etc/frr frrouting/${frr_image}
 docker run -d --privileged  --name ibgp-multi-hop --network multi-hop-net --rm -v ${PWD}/e2etest/ibgp-multi-hop/:/etc/frr frrouting/${frr_image}
 


### PR DESCRIPTION
This commit changes the script to be suitable for Openshift cluster that is reachable from the executor via network - using the kubeconfig.